### PR TITLE
Force url library version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Valentin Vasilyev <valentin.vasilyev@outlook.com>", "Dzmitry Misiuk 
 
 
 [dependencies]
-url = "*"
+url = "0.5.9"
 hyper = "*"
 rustc-serialize = "*"
 time="*"


### PR DESCRIPTION
rust-url 1.0.0 was release not so long ago and some breaking changes around UrlParser make the build to fail.
Until the integration of rust-url 1.x.x is fixed, this make the build to pass.